### PR TITLE
fix: Workers のデプロイ失敗を解消し、Node.js / pnpm のバージョンを固定する

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,12 +13,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: v20.x
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 8
-          run_install: true
+          node-version-file: package.json
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
       - name: Check
         run: |
           pnpm astro check

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ pnpm-debug.log*
 
 # jetbrains setting folder
 .idea/
+
+# wrangler files
+.wrangler

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "postinstall": "flowbite-react patch"
   },
   "volta": {
-    "node": "20.20.2"
+    "node": "24.18.1"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@11.18.0+sha512.33d83c77da82f49fba836925c6f1b841181ec3132b670639bd012f7075f5c7cf634c5f870147c19aae7478fac01df09d8892e880454896edd23ee9b33757563c",
   "dependencies": {
     "@astrojs/check": "^0.9.0",
     "@astrojs/mdx": "^2.2.4",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+# pnpm 10 以降は依存パッケージのビルドスクリプトが既定でブロックされるため、
+# 必要なものだけ明示的に許可する
+allowBuilds:
+  "@biomejs/biome": true
+  esbuild: true
+  sharp: true

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,10 @@
+{
+  "name": "blog",
+  "compatibility_date": "2026-08-01",
+  "assets": {
+    "directory": "./dist"
+  },
+  "observability": {
+    "enabled": true
+  }
+}


### PR DESCRIPTION
## 概要

Cloudflare Workers のデプロイが失敗し続けていた原因を調査し、その修正とツールチェインのバージョン固定を行います。

コミットは2つに分かれています。

| コミット | 内容 |
|---|---|
| `01bd392` | `wrangler.jsonc` 追加（デプロイ失敗の修正） |
| `7cac469` | Node.js / pnpm のバージョン固定 |

## 1. デプロイ失敗の修正

Workers Builds は初期セットアップ以降、**全9件中7件が失敗**していました。ビルド自体は毎回成功しており、落ちていたのは deploy ステップです。

```
Executing user deploy command: npx wrangler versions upload
✘ [ERROR] Missing entry-point to Worker script or to assets directory
```

Cloudflare が連携時（2026-06-12）に自動生成した `cloudflare/workers-autoconfig` ブランチが **main にマージされていない**ため、main に Wrangler 設定が一切存在しないことが原因でした。

本サイトは完全な静的出力（`[build] output: "static"`）なので、autoconfig ブランチが入れようとしていた `@astrojs/cloudflare` アダプタ・`output: "hybrid"`・`public/.assetsignore` は不要と判断し、assets のみの最小構成にしています。`name` は既存 Worker と一致させているため、新規 Worker は作られません。

実ビルド成果物に対する `wrangler deploy --dry-run` で `Read 32 files from the assets directory` を確認済みです。

## 2. Node.js / pnpm のバージョン固定

- **Node.js**: 20.20.2 → **24.18.1**（Active LTS 系の最新パッチ。v24 は 2025-10-28 に LTS 入り、メンテナンス移行は 2026-10-20）
- **pnpm**: 9.15.9 → **11.18.0**（`corepack use` で生成したため整合性ハッシュ付き）

### `pnpm-workspace.yaml` の追加が必須でした

pnpm 10 から依存パッケージの lifecycle script が既定でブロックされるようになり、そのまま上げると install が**エラー終了**します。

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts:
@biomejs/biome@1.9.4, esbuild@0.21.5, sharp@0.33.5
```

3つともプラットフォーム別バイナリの取得が実体で、動かないと biome / vite / 画像最適化が壊れるため、必要なものだけ `allowBuilds` で許可しています。なお `onlyBuiltDependencies` は pnpm 10.26 で `allowBuilds` に置き換わり、設定の置き場所も package.json から pnpm-workspace.yaml へ移っています。

### CI

`node-version: v20.x` と `pnpm/action-setup version: 8` がハードコードされており、固定したバージョンと矛盾していた（pnpm 8 指定は元々 `packageManager` の 9.15.9 ともズレていた）ため、Corepack ベースに統一しました。Node のバージョンは `node-version-file: package.json` で `volta.node` を読ませ、package.json を単一の情報源にしています。

## `pnpm-lock.yaml` は無変更です

pnpm 11 は既存の lockfile をそのまま読めるため、依存バージョンは1つも動いていません。別途予定している依存の一括更新PRとは競合しません。

## 検証結果

Node 24.18.1 + pnpm 11.18.0 で実行:

- `pnpm install --frozen-lockfile` → 成功。3つの build script が実行されることを確認
- `astro build` → 10ページ + sitemap 生成まで成功
- `biome ci` → exit 0
- `wrangler deploy --dry-run` → 実ビルド成果物 32ファイルを認識

## 注意点

- **このPRを先にマージしないと、他のPRも同じデプロイエラーで落ち続けます。**
- Cloudflare の既定 pnpm は 10.11.1 です。過去ログの `Detected the following tools from environment: pnpm@9.15.9` が `packageManager` の値と一致していたため 11.18.0 も検出される見込みですが、もし 10.11.1 のまま走った場合は Build Variables に `PNPM_VERSION = 11.18.0` を設定してください。
- Workers Builds は `volta` フィールドを読まないため、ビルド環境の Node は Cloudflare の既定値（現在 24.18.0、同じ LTS 系）になります。厳密に揃えたい場合は Build Variables に `NODE_VERSION = 24.18.1` を設定してください。
- 別件として、`@astrojs/sitemap` 3.7.x は Astro 4 と非互換で、renovate ブランチではビルド段階で `Cannot read properties of undefined (reading 'reduce')` が発生します（sitemap 3.7.1 が Astro 5 以降の API に切り替えたため）。こちらは依存の一括更新PRで対応予定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
